### PR TITLE
Make it easier for beginners to use hooks

### DIFF
--- a/h5pmods.php
+++ b/h5pmods.php
@@ -207,40 +207,40 @@ add_filter('h5p_alter_user_result', 'h5pmods_alter_user_result', 10, 4);
  * @return object|null Semantics field or null if not found.
  */
 function find_semantics_path($path, &$semantics) {
-	// Sanitization for user convenience
-	$path = (substr($path, 0, 1) === '/') ? substr($path, 1) : $path;
-	$path = (substr($path, -1) === '/') ? substr($path, 0, -1) : $path;
+  // Sanitization for user convenience
+  $path = (substr($path, 0, 1) === '/') ? substr($path, 1) : $path;
+  $path = (substr($path, -1) === '/') ? substr($path, 0, -1) : $path;
 
-	$path_segments = explode('/', $path);
+  $path_segments = explode('/', $path);
 
-	if (!is_object($semantics)) {
-		// Array
-		foreach($semantics as $object) {
-			if ($object->name === $path_segments[0]) {
-				return find_semantics_path($path, $object);
-			}
-		}
-	}
-	elseif (sizeof($path_segments) === 1 && $path_segments[0] === $semantics->name) {
-		// Found
-		return $semantics;
-	}
-	elseif (isset($semantics->field)) {
-		// List
-		array_shift($path_segments);
-		$path_short = implode($path_segments, '/');
-		return find_semantics_path($path_short, $semantics->field);
-	}
-	elseif (isset($semantics->fields)) {
-		// Group
+  if (!is_object($semantics)) {
+    // Array
+    foreach($semantics as $object) {
+      if ($object->name === $path_segments[0]) {
+        return find_semantics_path($path, $object);
+      }
+    }
+  }
+  elseif (sizeof($path_segments) === 1 && $path_segments[0] === $semantics->name) {
+    // Found
+    return $semantics;
+  }
+  elseif (isset($semantics->field)) {
+    // List
+    array_shift($path_segments);
+    $path_short = implode($path_segments, '/');
+    return find_semantics_path($path_short, $semantics->field);
+  }
+  elseif (isset($semantics->fields)) {
+    // Group
     array_shift($path_segments);
     $path_short = implode($path_segments, '/');
     return find_semantics_path($path_short, $semantics->fields);
-	}
-	else {
-		// Not found
-		return null;
-	}
+  }
+  else {
+    // Not found
+    return null;
+  }
 }
 
 /**
@@ -254,31 +254,31 @@ function find_semantics_path($path, &$semantics) {
  * @return object|null Semantics field or null if not found.
  */
 function find_semantics_field($field, &$semantics) {
-	if (!is_object($semantics)) {
-		// Array
-		$found = null;
-		foreach($semantics as $object) {
-			$found = find_semantics_field($field, $object);
-			if ($found !== null) {
-				break; // Return first matching field
-			}
-		}
-		return $found;
-	}
-	elseif ($semantics->name === $field) {
-		// Found
-		return $semantics;
-	}
-	elseif (isset($semantics->field)) {
-		// List
-		return find_semantics_field($field, $semantics->field);
-	}
-	elseif (isset($semantics->fields)) {
-		// Group
-		return find_semantics_field($field, $semantics->fields);
-	}
-	else {
-		// Not found
-		return null;
-	}
+  if (!is_object($semantics)) {
+    // Array
+    $found = null;
+    foreach($semantics as $object) {
+      $found = find_semantics_field($field, $object);
+      if ($found !== null) {
+        break; // Return first matching field
+      }
+    }
+    return $found;
+  }
+  elseif ($semantics->name === $field) {
+    // Found
+    return $semantics;
+  }
+  elseif (isset($semantics->field)) {
+    // List
+    return find_semantics_field($field, $semantics->field);
+  }
+  elseif (isset($semantics->fields)) {
+    // Group
+    return find_semantics_field($field, $semantics->fields);
+  }
+  else {
+    // Not found
+    return null;
+  }
 }

--- a/h5pmods.php
+++ b/h5pmods.php
@@ -86,6 +86,18 @@ add_action('h5p_alter_filtered_parameters', 'h5pmods_alter_parameters', 10, 4);
  * In this example we're going add a custom script which keeps track of the
  * scoring for drag 'n drop tasks.
  *
+ * The path can be relative to wp-content/uploads/h5p, so
+ * 'path' => '/score-tracking.js',
+ * would try to load wp-content/uploads/h5p/score-tracking.js
+ *
+ * The path can be absolute, so
+ * 'path' => 'http://mydomain.org/score-tracking.js',
+ * would to try to load the script from the URL
+ *
+ * The path can be retrieved using WordPress functions, so for instance
+ * 'path' => plugin_dir_url( __FILE__ ) . 'scripts/score-tracking.js',
+ * will try to load scripts/score-tracking.js inside this plugin's folder
+ *
  * @param object &$scripts List of JavaScripts that will be loaded.
  * @param array $libraries The libraries which the scripts belong to.
  * @param string $embed_type Possible values are: div, iframe, external, editor.
@@ -94,7 +106,7 @@ function h5pmods_alter_scripts(&$scripts, $libraries, $embed_type) {
   if (isset($libraries['H5P.DragQuestion'])) {
     $scripts[] = (object) array(
       // Path can be relative to wp-content/uploads/h5p or absolute.
-      'path' => '/score-tracking.js',
+      'path' => plugin_dir_url( __FILE__ ) . 'scripts/score-tracking.js',
       'version' => '?ver=1.2.3' // Cache buster
     );
   }

--- a/h5pmods.php
+++ b/h5pmods.php
@@ -32,9 +32,10 @@ if (!defined('WPINC')) {
 /**
  * Allows you to alter the H5P library semantics, i.e. changing how the
  * editor looks and how content parameters are filtered.
+ * Details on semantics structure: {@link} https://h5p.org/semantics
  *
- * In this example we change the preview label for the collage tool where
- * version is < 1.0.0.
+ * In this example we change the text label for multiple choice questions and
+ * the default value for the "Show Solution" button where the version is < 2.0.0
  *
  * @param object &$semantics The same as in semantics.json
  * @param string $name The machine readable name of the library.
@@ -42,18 +43,25 @@ if (!defined('WPINC')) {
  * @param int $minorVersion Second part of the version number.
  */
 function h5pmods_alter_semantics(&$semantics, $name, $majorVersion, $minorVersion) {
-  if ($name === 'H5P.Collage' && $majorVersion < 1) {
+  if ($name === 'H5P.MultiChoice' && $majorVersion < 2) {
 
-    // Find correct field
-    for ($i = 0, $l = count($semantics); $i < $l; $i++) {
-      $field = $semantics[$i];
+    /*
+     * Change the "text" label of answer options to "Option text"
+     * Note that find_semantics_path expects the full path to a field
+     */
+    $options_text = find_semantics_path('answers/answer/text', $semantics);
+    if (isset($options_text)) {
+      $options_text->label = 'Option text';
+    }
 
-      if ($field->name === 'collage') {
-
-        // Found our field, change label
-        $field->label = 'Altered Label';
-        return;
-      }
+    /*
+     * Hide the "Show Solution" button by default (for new content)
+     * Note that find_semantics_field expects the field name only and retrieves
+     * the first field of that name found.
+     */
+    $enableSolutionsButton = find_semantics_field('enableSolutionsButton', $semantics);
+    if (isset($enableSolutionsButton)) {
+      $enableSolutionsButton->default = false;
     }
   }
 }
@@ -181,3 +189,96 @@ function h5pmods_alter_user_result(&$data, $result_id, $content_id, $user_id) {
   }
 }
 add_filter('h5p_alter_user_result', 'h5pmods_alter_user_result', 10, 4);
+
+/*
+ * ============================================================================
+ * Utility functions
+ * ============================================================================
+ */
+
+/**
+ * Find semantics for a particular path/field.
+ *
+ * Helps to retrieve a specific field in semantics that is identified by its
+ * path including the field name.
+ *
+ * @param string $path Path/field to find, use / to separate levels.
+ * @param object &$semantics Reference to semantics to look in.
+ * @return object|null Semantics field or null if not found.
+ */
+function find_semantics_path($path, &$semantics) {
+	// Sanitization for user convenience
+	$path = (substr($path, 0, 1) === '/') ? substr($path, 1) : $path;
+	$path = (substr($path, -1) === '/') ? substr($path, 0, -1) : $path;
+
+	$path_segments = explode('/', $path);
+
+	if (!is_object($semantics)) {
+		// Array
+		foreach($semantics as $object) {
+			if ($object->name === $path_segments[0]) {
+				return find_semantics_path($path, $object);
+			}
+		}
+	}
+	elseif (sizeof($path_segments) === 1 && $path_segments[0] === $semantics->name) {
+		// Found
+		return $semantics;
+	}
+	elseif (isset($semantics->field)) {
+		// List
+		array_shift($path_segments);
+		$path_short = implode($path_segments, '/');
+		return find_semantics_path($path_short, $semantics->field);
+	}
+	elseif (isset($semantics->fields)) {
+		// Group
+    array_shift($path_segments);
+    $path_short = implode($path_segments, '/');
+    return find_semantics_path($path_short, $semantics->fields);
+	}
+	else {
+		// Not found
+		return null;
+	}
+}
+
+/**
+ * Find semantics for first matching field.
+ *
+ * Helps to retrieve a specific field in semantics but will only return the
+ * first match if there are multiple fields bearing the same name.
+ *
+ * @param string $field Field to find.
+ * @param object &$semantics Reference to semantics to look in.
+ * @return object|null Semantics field or null if not found.
+ */
+function find_semantics_field($field, &$semantics) {
+	if (!is_object($semantics)) {
+		// Array
+		$found = null;
+		foreach($semantics as $object) {
+			$found = find_semantics_field($field, $object);
+			if ($found !== null) {
+				break; // Return first matching field
+			}
+		}
+		return $found;
+	}
+	elseif ($semantics->name === $field) {
+		// Found
+		return $semantics;
+	}
+	elseif (isset($semantics->field)) {
+		// List
+		return find_semantics_field($field, $semantics->field);
+	}
+	elseif (isset($semantics->fields)) {
+		// Group
+		return find_semantics_field($field, $semantics->fields);
+	}
+	else {
+		// Not found
+		return null;
+	}
+}

--- a/h5pmods.php
+++ b/h5pmods.php
@@ -105,8 +105,17 @@ add_action('h5p_alter_library_scripts', 'h5pmods_alter_scripts', 10, 3);
  * Allows you to alter which stylesheets are loaded for H5P. This is
  * useful for adding your own custom styles or replacing existing once.
  *
- * In this example we're going add a custom script which keeps track of the
- * scoring for drag 'n drop tasks.
+ * The path can be relative to wp-content/uploads/h5p, so
+ * 'path' => '/mystyles.css',
+ * would try to load wp-content/uploads/h5p/mystyles.css
+ *
+ * The path can be absolute, so
+ * 'path' => 'http://mydomain.org/custom-h5p-styling.css',
+ * would to try to load the styles from the URL
+ *
+ * The path can be retrieved using WordPress functions, so for instance
+ * 'path' => plugin_dir_url( __FILE__ ) . 'styles/general.css',
+ * will try to load styles/general.css inside this plugin's folder
  *
  * @param object &styles List of stylesheets that will be loaded.
  * @param array $libraries The libraries which the styles belong to.
@@ -114,8 +123,11 @@ add_action('h5p_alter_library_scripts', 'h5pmods_alter_scripts', 10, 3);
  */
 function h5pmods_alter_styles(&$styles, $libraries, $embed_type) {
   $styles[] = (object) array(
-    // Path can be relative to wp-content/uploads/h5p or absolute.
-    'path' => 'http://mydomain.org/custom-h5p-styling.css',
+    /*
+     * Path can be relative to wp-content/uploads/h5p or absolute or set using
+     * WordPress functions
+     */
+    'path' => plugin_dir_url( __FILE__ ) . 'styles/general.css',
     'version' => '?ver=1.3.7' // Cache buster
   );
 }

--- a/scripts/score-tracking.js
+++ b/scripts/score-tracking.js
@@ -1,0 +1,30 @@
+/*
+ * Simple sample script to track H5P scores via xAPI
+ * See {@link https://h5p.org/documentation/x-api} for details on xAPI tracking
+ */
+(function () {
+  if (!H5P || !H5P.externalDispatcher) {
+    return; // Cannot track scores
+  }
+
+  /**
+   * Handle xAPI statements from H5P.
+   * {@link https://h5p.org/documentation/api/H5P.XAPIEvent.html}
+   *
+   * @param {H5P.XAPIEvent} Event containing xAPI data.
+   */
+  const xAPIHandler = function (event) {
+    // xAPI uses JSON
+    const xAPI = event.data.statement;
+
+    if (!xAPI.result) {
+      return; // No result in xAPI statement
+    }
+
+    // Output score object to console
+    console.log(xAPI.result.score);
+  };
+
+  // Listen to xAPI statements
+  H5P.externalDispatcher.on('xAPI', xAPIHandler);
+}());

--- a/styles/general.css
+++ b/styles/general.css
@@ -1,0 +1,3 @@
+.h5p-container {
+  border: 0.1em dashed #ccc;
+}


### PR DESCRIPTION
Beginners often find it difficult to use hooks, even for seemingly simple things like adding a custom stylesheet. When merged in, the plugin will make it easier to customize H5P by:

- adding and calling a sample stylesheet from the plugin directory
- adding a sample script loaded from the plugin directory (that itself may help to utilize xAPI)
- adding and using utility functions to retrieve fields from semantics
- adding links to documentation